### PR TITLE
Settings Linux compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ Utilities/*
 !tmp/.gitkeep
 tmp
 opencore-*.txt
+oc*_mac*.tar.gz
+oc*_mac*.zip
 .Spotlight-V100
 .Trashes
 .fseventsd

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -240,7 +240,7 @@
 			<key>RebuildAppleMemoryMap</key>
 			<true/>
 			<key>ResizeAppleGpuBars</key>
-			<integer>-1</integer>
+			<integer>0</integer>
 			<key>SetupVirtualMap</key>
 			<false/>
 			<key>SignalAppleOS</key>

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -747,7 +747,7 @@
 			<key>AppleXcpmForceBoost</key>
 			<false/>
 			<key>CustomSMBIOSGuid</key>
-			<false/>
+			<true/>
 			<key>DisableIoMapper</key>
 			<true/>
 			<key>DisableLinkeditJettison</key>
@@ -1044,7 +1044,7 @@
 		<key>UpdateSMBIOS</key>
 		<true/>
 		<key>UpdateSMBIOSMode</key>
-		<string>Create</string>
+		<string>Custom</string>
 		<key>UseRawUuidEncoding</key>
 		<false/>
 	</dict>

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,7 @@ clean_base: clean
 
 clean_log:
 	rm -rf ./opencore-*.txt
+
+package:
+	tar -czvf oc$(version_opencore)_mac`sw_vers -productVersion`.tar.gz EFI/
+	zip -r oc$(version_opencore)_mac`sw_vers -productVersion`.zip EFI/


### PR DESCRIPTION
- Set the minimum supported BAR size `ResizeAppleGpuBars` to 0.
- Make SMBIOS updates exclusive to macOS. This is to avoid write data to any other OS.